### PR TITLE
Add entry_point, remove deps unneeded with noarch

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,5 +6,3 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-target_platform:
-- linux-64

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @astamminger
+* @astamminger @bollwyvl

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About shortuuid
 ===============
 
-Home: https://github.com/stochastic-technologies/shortuuid/
+Home: https://github.com/skorokithakis/shortuuid
 
 Package license: BSD-3-Clause
 

--- a/README.md
+++ b/README.md
@@ -149,4 +149,5 @@ Feedstock Maintainers
 =====================
 
 * [@astamminger](https://github.com/astamminger/)
+* [@bollwyvl](https://github.com/bollwyvl/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "shortuuid" %}
-{% set version = "1.0.10" %}
-{% set sha256 = "666e1e8a47379b3626ec40da17d3635212ea232b4647e808ea46d1c4b0be156e" %}
+{% set version = "1.0.11" %}
+{% set sha256 = "fc75f2615914815a8e4cb1501b3a513745cb66ef0fd5fc6fb9f8c3fa3481f789" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,42 +1,44 @@
-{% set name = "shortuuid" %}
 {% set version = "1.0.10" %}
-{% set sha256 = "666e1e8a47379b3626ec40da17d3635212ea232b4647e808ea46d1c4b0be156e" %}
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: shortuuid
+  version: 666e1e8a47379b3626ec40da17d3635212ea232b4647e808ea46d1c4b0be156e
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/s/shortuuid/shortuuid-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
-  number: 0
+  script:
+    # TODO: remove after https://github.com/skorokithakis/shortuuid/pull/90
+    - {{ PYTHON }} -c "__import__('pathlib').Path('shortuuid/py.typed').touch()"
+    - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  number: 1
+  entry_points:
+    - shortuuid = shortuuid.cli:cli
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - poetry
   host:
-    - python >=3.6
     - pip
-    - poetry
+    - poetry-core
+    - python >=3.6
   run:
     - python >=3.6
 
 test:
   requires:
     - pep8
+    - pip
   imports:
     - shortuuid
   commands:
+    - pip check
+    - shortuuid --help
     - python -m unittest shortuuid.test_shortuuid
 
 about:
-  home: https://github.com/stochastic-technologies/shortuuid/
+  home: https://github.com/skorokithakis/shortuuid
   license: BSD-3-Clause
   license_file: COPYING
   summary: A generator library for concise, unambiguous and URL-safe UUIDs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,3 +47,4 @@ about:
 extra:
   recipe-maintainers:
     - astamminger
+    - bollwyvl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,11 +2,11 @@
 
 package:
   name: shortuuid
-  version: 666e1e8a47379b3626ec40da17d3635212ea232b4647e808ea46d1c4b0be156e
+  version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/s/shortuuid/shortuuid-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 666e1e8a47379b3626ec40da17d3635212ea232b4647e808ea46d1c4b0be156e
 
 build:
   noarch: python


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Notes:
- removes  some jinja variables
- updates some package metadata
- remove un-needed cross-build deps
- ensure the `shortuuid` CLI via `entry_points` 
- smoke test CLI
- use `poetry-core` instead of full-fat `poetry`
- add `pip check`
- ~~temporarily force creating the `py.typed` marker (upstream PR created)~~
- add self a maintainer :wave: 